### PR TITLE
Use mock data for dashboards and listings

### DIFF
--- a/src/app/api/auth/route.tsx
+++ b/src/app/api/auth/route.tsx
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server'
 import jwt from 'jsonwebtoken'
 
 export async function POST(req: NextRequest) {
-  const { username, password } = await req.json()
+  const { username } = await req.json()
   const token = jwt.sign({ username }, "TREKOOOO", {
     expiresIn: '6h',
   })

--- a/src/app/modules/base/campaigns/page.tsx
+++ b/src/app/modules/base/campaigns/page.tsx
@@ -2,41 +2,47 @@
 "use client";
 
 import CampaignCard from "@/components/campaign-card";
-import React, { useEffect, useState } from "react";
+import campains from "@/lib/campains.js";
+import React, { useMemo } from "react";
 
 type Campaign = {
   id: number;
-  name: string;
+  campain_name: string;
+  description: string;
+  start_date: string;
+  end_date: string;
+  estatus: string;
   goal: number;
-  startDate: string;
-  endDate: string;
-  academicEntityId: number;
-  totalDonations: number;
+  current_value: number;
+  accepted: string;
+  isExpired: boolean;
 };
 
 export default function CampaignsPages() {
-  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const campaigns = useMemo<Campaign[]>(
+    () => [...(campains as Campaign[])],
+    []
+  );
 
-  useEffect(() => {
-    async function fetchCampaigns() {
-      try {
-        const response = await fetch("http://localhost:8000/campaigns");
-        if (!response.ok) throw new Error("Failed to fetch campaigns");
-        const result = await response.json();
-        setCampaigns(result.data);
-      } catch (error) {
-        console.error("Error fetching campaigns:", error);
-      }
-    }
-    fetchCampaigns();
-  }, []);
+  const sortedCampaigns = useMemo(
+    () =>
+      [...campaigns].sort((a, b) => {
+        if (a.isExpired !== b.isExpired) {
+          return a.isExpired ? 1 : -1;
+        }
+        return (
+          new Date(a.end_date).getTime() - new Date(b.end_date).getTime()
+        );
+      }),
+    [campaigns]
+  );
 
   return (
     <div className="flex flex-1 flex-col">
       <div className="@container/main flex flex-1 flex-col gap-2">
         <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
           <div className="grid grid-cols-1 w-full sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
-            {campaigns.map((campaign: Campaign) => (
+            {sortedCampaigns.map((campaign: Campaign) => (
               <CampaignCard key={campaign.id} campaign={campaign} />
             ))}
           </div>

--- a/src/app/modules/base/donations/page.tsx
+++ b/src/app/modules/base/donations/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { DonationsDataTable } from "@/components/donations-data-table";
-import { FetchServerResponseOptions } from "next/dist/client/components/router-reducer/fetch-server-response";
+import donations from "@/lib/donations.js";
 
 interface Donation {
   id: number;
@@ -14,58 +14,16 @@ interface Donation {
 }
 
 export default function DonationsPage() {
-  const [donations, setDonations] = useState<Donation[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function fetchDonations() {
-      try {
-        const response = await fetch("http://localhost:8000/donations");
-
-        if (!response.ok) {
-          throw new Error(`Erro HTTP! Status: ${response.status}`);
-        }
-
-        const result = await response.json();
-        setDonations(result.data);
-      } catch (err: any) {
-        console.error("Erro ao carregar doações:", err);
-        setError(`Não foi possível carregar as doações: ${err.message || 'Erro desconhecido'}`);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchDonations();
+  const donationData = useMemo<Donation[]>(() => {
+    return [...(donations as Donation[])].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
   }, []);
-
-  if (loading) {
-    return (
-      <div className="p-4 flex justify-center items-center h-64">
-        <p>Carregando dados das doações...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-4 text-red-600 flex flex-col justify-center items-center h-64">
-        <p>{error}</p>
-        <button
-          className="mt-4 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-          onClick={() => window.location.reload()}
-        >
-          Tentar Novamente
-        </button>
-      </div>
-    );
-  }
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Donations</h1>
-      <DonationsDataTable data={donations} />
+      <h1 className="text-2xl font-bold mb-4">Doações</h1>
+      <DonationsDataTable data={donationData} />
     </div>
   );
 }

--- a/src/app/modules/base/orgs/[:id]/page.tsx
+++ b/src/app/modules/base/orgs/[:id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useOrg } from "@/app/providers/OrgProvider"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
+import Image from "next/image"
 import { useParams } from "next/navigation"
 import { useEffect } from "react"
 import { TOrg } from "../page"
@@ -49,8 +50,15 @@ export default function Org() {
 	if (currentOrg) {
 		return (
 			<div className="w-full min-h-full flex flex-col items-center justify-center p-2 rounded-4xl">
-				<div className="relative w-full h-48 overflow-hidden flex items-center justify-start border-red-500 border-2 rounded-t-2xl">
-					<img src={currentOrg.image_url ?? '/academic-donations.png'} alt="Banner" className="w-full h-full object-cover" />
+                                <div className="relative w-full h-48 overflow-hidden flex items-center justify-start border-red-500 border-2 rounded-t-2xl">
+                                        <Image
+                                                src={currentOrg.image_url ?? '/academic-donations.png'}
+                                                alt="Banner"
+                                                fill
+                                                unoptimized
+                                                sizes="(max-width: 1024px) 100vw, 100vw"
+                                                className="object-cover"
+                                        />
 					<div className="bg-black/60 absolute inset-0 z-10" />
 					<p className="absolute z-20 p-6 text-white text-2xl font-medium">
 						{currentOrg.name}

--- a/src/components/campaign-card.tsx
+++ b/src/components/campaign-card.tsx
@@ -1,25 +1,19 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { format } from "date-fns";
 
 type Campaign = {
   id: number;
-  name: string;
+  campain_name: string;
+  description: string;
+  start_date: string;
+  end_date: string;
+  estatus: string;
   goal: number;
-  startDate: string;
-  endDate: string;
-  academicEntity: AcademicEntity;
-  totalDonations: number;
-};
-
-type AcademicEntity = {
-  id: number;
-  type: string;
-  fantasyName: string;
-  cnpj: string;
-  foundationDate: string;
-  status: string;
-  cep: string;
+  current_value: number;
+  accepted: string;
+  isExpired: boolean;
 };
 
 interface CampaignCardProps {
@@ -28,29 +22,48 @@ interface CampaignCardProps {
 
 export default function CampaignCard({ campaign }: CampaignCardProps) {
   const percentage = Math.min(
-    (campaign.totalDonations / campaign.goal) * 100,
+    (campaign.current_value / campaign.goal) * 100,
     100
   );
+  const startDate = new Date(campaign.start_date);
+  const endDate = new Date(campaign.end_date);
+  const statusLabel = campaign.isExpired
+    ? "Expirada"
+    : campaign.estatus === "active"
+    ? "Ativa"
+    : "Inativa";
 
   return (
     <Card
       key={campaign.id}
       className="rounded-2xl shadow-md w-full max-w-sm md:max-w-md lg:max-w-lg mx-auto"
+      data-slot="card"
     >
       <CardHeader>
-        <CardTitle className="text-xl">{campaign.name}</CardTitle>
-        <div className="text-l">{campaign.academicEntity.fantasyName}</div>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-xl">{campaign.campain_name}</CardTitle>
+          <Badge variant={campaign.isExpired ? "destructive" : "outline"}>
+            {statusLabel}
+          </Badge>
+        </div>
         <p className="text-sm text-gray-500">
-          {format(new Date(campaign.startDate), "PPP")} -{" "}
-          {format(new Date(campaign.endDate), "PPP")}
+          {format(startDate, "PPP")} - {format(endDate, "PPP")}
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="text-sm">Goal: ${campaign.goal}</div>
-        <div className="text-sm">Raised: ${campaign.totalDonations}</div>
+        <p className="text-sm text-muted-foreground">
+          {campaign.description}
+        </p>
+        <div className="text-sm">Meta: R${campaign.goal.toLocaleString()}</div>
+        <div className="text-sm">
+          Arrecadado: R${campaign.current_value.toLocaleString()}
+        </div>
         <Progress value={percentage} className="h-4" />
         <div className="text-right text-xs text-muted-foreground">
           {percentage.toFixed(2)}% atingido da meta
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Aceita doações em: <strong>{campaign.accepted}</strong>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- render campaign cards directly from the mocked data set and enhance the card UI with status details
- build dashboard metrics from the mocked donations list, including monetary totals and retention/churn trends
- drive donations table from the local mock data, add runtime validation, and clean up lint issues
- improve the donations table filters and formatting with localized labels and currency output

## Testing
- pnpm lint *(fails: next not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb58ed366c8329bc4961dab37fadcb